### PR TITLE
update: add ``reduce`` option to ``eval_multi_ovr``

### DIFF
--- a/example/eval_and_predict.py
+++ b/example/eval_and_predict.py
@@ -1,10 +1,10 @@
 import numpy as np
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import roc_auc_score as auroc
 from utils import load_data, print_expected
 
 from nleval import Dataset
 from nleval.label.split import RatioPartition
+from nleval.metric import auroc
 from nleval.model_trainer import SupervisedLearningTrainer
 from nleval.util.parallel import ParDatMap
 

--- a/example/filter_by_split.py
+++ b/example/filter_by_split.py
@@ -1,11 +1,11 @@
 from time import perf_counter
 
 import numpy as np
-from sklearn.metrics import roc_auc_score as auroc
 from utils import load_data, print_expected
 
 from nleval.label.filters import LabelsetRangeFilterSplit
 from nleval.label.split import RatioPartition
+from nleval.metric import auroc
 from nleval.model.label_propagation import OneHopPropagation
 from nleval.model_trainer import LabelPropagationTrainer
 

--- a/example/gcn_studybias_holdout.py
+++ b/example/gcn_studybias_holdout.py
@@ -1,10 +1,10 @@
 import torch
-from sklearn.metrics import roc_auc_score as auroc
 from torch_geometric.nn import GCN
 from utils import load_data
 
 from nleval import Dataset
 from nleval.label.split import RatioPartition
+from nleval.metric import auroc
 from nleval.model_trainer.gnn import SimpleGNNTrainer
 
 # Load dataset (with sparse graph)

--- a/example/graphgym_studybias_holdout.py
+++ b/example/graphgym_studybias_holdout.py
@@ -42,7 +42,7 @@ print(f"\nBest results:\n{results}\n")
 
 # Check to see if the model is rewinded back to the best model correctly
 data = dataset.to_pyg_data(device=trainer.device)
-y_pred, y_true = graphgym_model_wrapper(mdl)(data, dataset.y)
+y_pred, y_true = graphgym_model_wrapper(mdl)(data)
 for split in "train", "val", "test":
     mask = dataset.masks[split][:, 0]
     print(f"{split:>5}: {auroc(y_true[mask], y_pred[mask])}")

--- a/example/label_propagation_studybias_holdout.py
+++ b/example/label_propagation_studybias_holdout.py
@@ -1,8 +1,8 @@
-from sklearn.metrics import roc_auc_score as auroc
 from utils import load_data, print_expected
 
 from nleval import Dataset
 from nleval.label.split import RatioPartition
+from nleval.metric import auroc
 from nleval.model.label_propagation import OneHopPropagation
 from nleval.model_trainer import LabelPropagationTrainer
 
@@ -31,7 +31,7 @@ print(trainer.train(mdl, dataset))
 
 # Evaluate the model for all tasks
 dataset = Dataset(graph=g, label=lsc, splitter=splitter)
-results = trainer.eval_multi_ovr(mdl, dataset, consider_negative=True)
+results = trainer.eval_multi_ovr(mdl, dataset, consider_negative=True, reduce="mean")
 print(f"Average train score = {results['train_auroc']:.4f}")
 print(f"Average test score = {results['test_auroc']:.4f}")
 

--- a/example/logistic_regression_studybias_holdout.py
+++ b/example/logistic_regression_studybias_holdout.py
@@ -1,9 +1,9 @@
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import roc_auc_score as auroc
 from utils import load_data, print_expected
 
 from nleval import Dataset
 from nleval.label.split import RatioPartition
+from nleval.metric import auroc
 from nleval.model_trainer import SupervisedLearningTrainer
 
 # Load dataset
@@ -32,7 +32,7 @@ print(trainer.train(mdl, dataset))
 
 # Evaluate the model for all tasks
 dataset = Dataset(feature=feature, label=lsc, splitter=splitter)
-results = trainer.eval_multi_ovr(mdl, dataset, consider_negative=True)
+results = trainer.eval_multi_ovr(mdl, dataset, consider_negative=True, reduce="mean")
 print(f"Average train score = {results['train_auroc']:.4f}")
 print(f"Average test score = {results['test_auroc']:.4f}")
 

--- a/example/n2v_hypertune_studybias_holdout.py
+++ b/example/n2v_hypertune_studybias_holdout.py
@@ -5,12 +5,12 @@ import tempfile
 
 import numpy as np
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import roc_auc_score as auroc
 from utils import load_data
 
 from nleval.feature import FeatureVec, MultiFeatureVec
 from nleval.label.filters import LabelsetRangeFilterSplit
 from nleval.label.split import RatioPartition
+from nleval.metric import auroc
 from nleval.model_trainer import (
     MultiSupervisedLearningTrainer,
     SupervisedLearningTrainer,

--- a/example/sl_predict.py
+++ b/example/sl_predict.py
@@ -1,9 +1,9 @@
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import roc_auc_score as auroc
 from utils import load_data
 
 from nleval import Dataset
 from nleval.label.split import AllHoldout
+from nleval.metric import auroc
 from nleval.model_trainer import SupervisedLearningTrainer
 
 i = 24  # index of labelset

--- a/src/nleval/model_trainer/base.py
+++ b/src/nleval/model_trainer/base.py
@@ -99,6 +99,7 @@ class StandardTrainer(BaseTrainer):
         dataset,
         split_idx: int = 0,
         consider_negative: bool = False,
+        reduce: str = "none",
     ) -> Dict[str, float]:
         """Evaluate the model in a multiclass setting.
 
@@ -127,7 +128,7 @@ class StandardTrainer(BaseTrainer):
             intermediate_results = compute_results(masks, label_idx=i)
             self.logger.info(f"{label_id}\t{intermediate_results}")
 
-        results = compute_results(dataset.masks)
+        results = compute_results(dataset.masks, reduce=reduce)
 
         return results
 
@@ -145,6 +146,7 @@ class StandardTrainer(BaseTrainer):
         def compute_results(
             masks,
             label_idx: Optional[int] = None,
+            reduce: str = "mean",
         ) -> Dict[str, float]:
             # Set up results compute function using the y dicts and the metrics
             results = {}
@@ -156,7 +158,7 @@ class StandardTrainer(BaseTrainer):
                         y_true = y_true[:, label_idx]
                         y_pred = y_pred[:, label_idx]
 
-                    score = metric_func(y_true, y_pred)
+                    score = metric_func(y_true, y_pred, reduce=reduce)
                     results[f"{mask_name}_{metric_name}"] = score
 
             return results

--- a/src/nleval/model_trainer/base.py
+++ b/src/nleval/model_trainer/base.py
@@ -158,7 +158,7 @@ class StandardTrainer(BaseTrainer):
                         y_true = y_true[:, label_idx]
                         y_pred = y_pred[:, label_idx]
 
-                    score = metric_func(y_true, y_pred, reduce=reduce)
+                    score = metric_func(y_true, y_pred, reduce=reduce)  # type: ignore
                     results[f"{mask_name}_{metric_name}"] = score
 
             return results

--- a/src/nleval/model_trainer/graphgym.py
+++ b/src/nleval/model_trainer/graphgym.py
@@ -237,13 +237,12 @@ class GraphGymTrainer(GNNTrainer):
 
 
 def graphgym_model_wrapper(model):
-    """Wrap a GraphGym model to take data and y as input."""
+    """Wrap a GraphGym model to take PyG data as input."""
 
     @wraps(model)
-    def wrapped_model(data, y):
+    def wrapped_model(data):
         batch = Batch.from_data_list([data])
-        batch.y = torch.Tensor(y)
-        batch.all_mask = torch.ones(y.shape[0], dtype=bool)
+        batch.all_mask = torch.ones(data.y.shape[0], dtype=bool)
         batch.split = "all"
         pred, true = model(batch)
         return pred.detach().cpu().numpy(), true.detach().cpu().numpy()


### PR DESCRIPTION
So that after evaluating the multiclass ovr setting, the results are not reduced by mean by default.